### PR TITLE
⬆️ Upgrade Transifex cli.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
         sudo apt-get install -y --no-install-recommends python3-tk pandoc
         pip install -U pip setuptools wheel
         pip install -r ./requirements.txt
+        curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash
     - name: update
       env:
         SPHINXINTL_TRANSIFEX_USERNAME: api


### PR DESCRIPTION
Subject: ⬆️ Upgrade Transifex cli.

### Feature or Bugfix
<!-- please choose -->
- Feature

### Purpose
- Upgrade Transifex CLI dependencies.

### Detail
- The deprecation period of API 2.0/2.5 and Transifex CLI is coming to an end. Calls to these APIs and any scripts that depend on them will not work after Nov 30, 2022. We highly recommend you migrate to newer versions before the sunset date.

### Relates
- https://github.com/transifex/cli