### PR TITLE
Add requirements-txt-fixer to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,4 @@ repos:
   rev: 0.18.4
   hooks:
     - id: check-github-workflows
+    - id: requirements-txt-fixer


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
I often forget to sort names when adding packages to the requirements file.
Adding `requirements-txt-fixer` option in `.pre-commit-config.yaml` prevents this human error.

<!-- Be sure to link other PRs or issues that relate to this PR here. --> 

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- None

